### PR TITLE
'それな'か'sorena'の時だけ反応するようにした

### DIFF
--- a/lib/ruboty/handlers/sorena.rb
+++ b/lib/ruboty/handlers/sorena.rb
@@ -3,7 +3,7 @@
 module Ruboty
   module Handlers
     class Sorena < Base
-      on /それな|sorena/i, name: "sorena", description: "Request それな", all: true
+      on /^(それな|sorena)$/i, name: "sorena", description: "Request それな", all: true
 
       def sorena(message)
         unless room(message.from) =~ ignored_channel


### PR DESCRIPTION
`それなら`とか`なにそれなにそれ`とかに反応してしまうのが邪魔なので`<文頭>それな<文末>`か`<文頭>sorena<文末>`のときだけ反応するようにした。